### PR TITLE
sidebarコンテンツにユーザ切り替え用モーダルページ表示動線追加

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     browser: true,
     es2021: true,
     mocha: true,
-    jest: true
+    jest: true,
   },
   extends: [
     'plugin:react/recommended',
@@ -14,29 +14,29 @@ module.exports = {
     // 'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:@typescript-eslint/recommended-requiring-type-checking',
-    'prettier'
+    'prettier',
   ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
-      jsx: true
+      jsx: true,
     },
     ecmaVersion: 12,
     sourceType: 'module',
-    project: './tsconfig.json'
+    project: './tsconfig.json',
   },
   plugins: ['react', '@typescript-eslint', 'import'],
   settings: {
     react: {
-      version: 'detect'
+      version: 'detect',
     },
     'import/resolver': {
       node: {
         paths: ['src'],
-        extensions: ['.js', '.jsx', '.ts', '.tsx']
-      }
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
+      },
     },
-    'import/extenstions': ['.js', '.jsx', '.ts', '.tsx']
+    'import/extenstions': ['.js', '.jsx', '.ts', '.tsx'],
   },
   rules: {
     'react/react-in-jsx-scope': 'off',
@@ -47,51 +47,43 @@ module.exports = {
         js: 'never',
         jsx: 'never',
         ts: 'never',
-        tsx: 'never'
-      }
+        tsx: 'never',
+      },
     ],
     'react/jsx-filename-extension': [
       'error',
       {
-        extensions: ['.jsx', '.tsx']
-      }
+        extensions: ['.jsx', '.tsx'],
+      },
     ],
     'no-void': [
       'error',
       {
-        allowAsStatement: true
-      }
+        allowAsStatement: true,
+      },
     ],
     'import/order': [
       'error',
       {
-        groups: [
-          'builtin',
-          'external',
-          'parent',
-          'sibling',
-          'index',
-          'object',
-          'type'
-        ],
+        groups: ['builtin', 'external', 'parent', 'sibling', 'index', 'object', 'type'],
         pathGroups: [
           {
             pattern: '{react,react-dom/**,react-router-dom}',
             group: 'builtin',
-            position: 'before'
+            position: 'before',
           },
           {
             pattern: '@src/**',
             group: 'parent',
-            position: 'before'
-          }
+            position: 'before',
+          },
         ],
         pathGroupsExcludedImportTypes: ['builtin'],
         alphabetize: {
-          order: 'asc'
+          order: 'asc',
         },
-        'newlines-between': 'always'
-      }
+        'newlines-between': 'always',
+      },
     ],
     /**
      * 変数をまとめて宣言するのを禁止するルール(デフォルトは許可)
@@ -103,6 +95,8 @@ module.exports = {
      * 開発中に制限に引っ掛かりがちなのでwarnにとどめる
      */
     'prefer-const': 'warn',
+    /**一重引用符を含まないすべての JSX 属性値に対して一重引用符の使用しなければいけない */
+    'jsx-quotes': ['error', 'prefer-single'],
     /**
      * 複数行コメントを書く時には // ではなく /** にしなければいけない。
      * 無効化
@@ -188,21 +182,13 @@ module.exports = {
       'warn',
       {
         /** ファイル種別に応じてimport順を変更 */
-        groups: [
-          'builtin',
-          'external',
-          'internal',
-          ['parent', 'sibling'],
-          'index',
-          'object',
-          'type'
-        ],
+        groups: ['builtin', 'external', 'internal', ['parent', 'sibling'], 'index', 'object', 'type'],
         /** importの改行処理　無効 */
         'newlines-between': 'never',
         /** アルファベット順に並び替える */
         alphabetize: {
           order: 'asc',
-          caseInsensitive: false
+          caseInsensitive: false,
         },
         /** パターンマッチしたものをグループにする */
         pathGroups: [
@@ -210,12 +196,12 @@ module.exports = {
             /** react関連をexternalより上に配置 */
             pattern: 'react',
             group: 'external',
-            position: 'before'
-          }
+            position: 'before',
+          },
         ],
         /**　未割り当てのimportをimportブロックの内部に含めるようにする */
-        warnOnUnassignedImports: true
-      }
+        warnOnUnassignedImports: true,
+      },
     ],
     /**
      * 変数名は2文字以上なければならない。
@@ -225,6 +211,6 @@ module.exports = {
     /** 末尾のスペースを許容しない */
     'no-trailing-spaces': 'warn',
     /** レギュラーな空白意外許容しない */
-    'no-irregular-whitespace': 'error'
-  }
+    'no-irregular-whitespace': 'error',
+  },
 };

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "printWidth": 120,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "semi": true,
+  "parser": "typescript"
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,28 @@
-import { ProSidebarProvider } from "react-pro-sidebar";
-import { RecoilRoot } from "recoil";
-import ErrorBoundary from "../src/common/errorBoundary";
-import MainArea from "../src/page/baseComponent/mainArea";
-import SearchArea from "../src/page/baseComponent/searchArea";
-import SidebarArea from "../src/page/baseComponent/sidebarArea";
-import "../src/style/app.css";
+import { ProSidebarProvider } from 'react-pro-sidebar';
+import { RecoilRoot } from 'recoil';
+import ErrorBoundary from '../src/common/errorBoundary';
+import MainArea from '../src/page/baseComponent/mainArea';
+import SearchArea from '../src/page/baseComponent/searchArea';
+import SidebarArea from '../src/page/baseComponent/sidebarArea';
+import UserChangeModal from '../src/page/modalArea/userChangeModal';
+import '../src/style/app.css';
 
 export default function App() {
   return (
     <RecoilRoot>
       <ErrorBoundary>
         <ProSidebarProvider>
-          <div className="base-wrapper">
-            <SidebarArea />
-            <MainArea />
-            <SearchArea />
+          <div className='base-wrapper'>
+            <div className='sidebar-wrapper'>
+              <SidebarArea />
+            </div>
+            <div className='main-wrapper'>
+              <MainArea />
+              <UserChangeModal />
+            </div>
+            <div className='search-wrapper'>
+              <SearchArea />
+            </div>
           </div>
         </ProSidebarProvider>
       </ErrorBoundary>

--- a/src/__tests__/page/mainArea.test.tsx
+++ b/src/__tests__/page/mainArea.test.tsx
@@ -1,12 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { unmountComponentAtNode } from "react-dom";
-import { act } from "react-dom/test-utils";
-import MainArea from "../../page/baseComponent/mainArea";
+import { render, screen } from '@testing-library/react';
+import { unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import MainArea from '../../page/baseComponent/mainArea';
 
 let container: any = null;
 beforeEach(() => {
   // setup a DOM element as a render target
-  container = document.createElement("div");
+  container = document.createElement('div');
   document.body.appendChild(container);
 });
 
@@ -17,8 +17,8 @@ afterEach(() => {
   container = null;
 });
 
-describe("初回レンダリング時", () => {
-  test("ダミーArea「プロフィール表示エリア」を示すテキスト", () => {
+describe('初回レンダリング時', () => {
+  test('ダミーArea「プロフィール表示エリア」を示すテキスト', () => {
     act(() => {
       render(<MainArea />, container);
     });
@@ -29,7 +29,7 @@ describe("初回レンダリング時", () => {
     expect(textElement).toBeInTheDocument();
   });
 
-  test("ダミーArea「TL表示エリア」を示すテキスト", () => {
+  test('ダミーArea「TL表示エリア」を示すテキスト', () => {
     act(() => {
       render(<MainArea />, container);
     });
@@ -38,7 +38,7 @@ describe("初回レンダリング時", () => {
     expect(textElement).toBeInTheDocument();
   });
 
-  test("ダミーArea「TabContents表示エリア」を示すテキスト", () => {
+  test('ダミーArea「TabContents表示エリア」を示すテキスト', () => {
     act(() => {
       render(<MainArea />, container);
     });

--- a/src/__tests__/page/searchArea.test.tsx
+++ b/src/__tests__/page/searchArea.test.tsx
@@ -1,12 +1,12 @@
-import { render, screen } from "@testing-library/react";
-import { unmountComponentAtNode } from "react-dom";
-import { act } from "react-dom/test-utils";
-import SearchArea from "../../page/baseComponent/searchArea";
+import { render, screen } from '@testing-library/react';
+import { unmountComponentAtNode } from 'react-dom';
+import { act } from 'react-dom/test-utils';
+import SearchArea from '../../page/baseComponent/searchArea';
 
 let container: any = null;
 beforeEach(() => {
   // setup a DOM element as a render target
-  container = document.createElement("div");
+  container = document.createElement('div');
   document.body.appendChild(container);
 });
 
@@ -17,8 +17,8 @@ afterEach(() => {
   container = null;
 });
 
-describe("初回レンダリング時", () => {
-  test("ダミーArea「検索バー表示エリア」を示すテキスト", () => {
+describe('初回レンダリング時', () => {
+  test('ダミーArea「検索バー表示エリア」を示すテキスト', () => {
     act(() => {
       render(<SearchArea />, container);
     });
@@ -29,7 +29,7 @@ describe("初回レンダリング時", () => {
     expect(textElement).toBeInTheDocument();
   });
 
-  test("ダミーArea「トレンド表示エリア」を示すテキスト", () => {
+  test('ダミーArea「トレンド表示エリア」を示すテキスト', () => {
     act(() => {
       render(<SearchArea />, container);
     });

--- a/src/__tests__/page/sidebarArea.test.tsx
+++ b/src/__tests__/page/sidebarArea.test.tsx
@@ -1,11 +1,8 @@
-import { render, RenderOptions, RenderResult } from "@testing-library/react";
-import React from "react";
-import { ProSidebarProvider } from "react-pro-sidebar";
+import { render, RenderOptions, RenderResult } from '@testing-library/react';
+import React from 'react';
+import { ProSidebarProvider } from 'react-pro-sidebar';
 
-type CustomRender = (
-  ui: React.ReactElement,
-  options?: Omit<RenderOptions, "wrapper">
-) => RenderResult;
+type CustomRender = (ui: React.ReactElement, options?: Omit<RenderOptions, 'wrapper'>) => RenderResult;
 
 interface AllTheProvidersProps {
   children?: React.ReactNode;
@@ -15,11 +12,9 @@ const AllTheProviders: React.FC<AllTheProvidersProps> = ({ children }) => (
   <ProSidebarProvider>{children}</ProSidebarProvider>
 );
 
-const customRender: CustomRender = (
-  ui: React.ReactElement,
-  options?: Omit<RenderOptions, "wrapper">
-) => render(ui, { wrapper: AllTheProviders, ...options });
+const customRender: CustomRender = (ui: React.ReactElement, options?: Omit<RenderOptions, 'wrapper'>) =>
+  render(ui, { wrapper: AllTheProviders, ...options });
 
-export * from "@testing-library/react";
+export * from '@testing-library/react';
 
 export { customRender };

--- a/src/common/deleteTimeline.ts
+++ b/src/common/deleteTimeline.ts
@@ -1,9 +1,9 @@
-import { collection, getDocs, doc, deleteDoc } from "firebase/firestore";
-import db from "../firebase";
+import { collection, getDocs, doc, deleteDoc } from 'firebase/firestore';
+import db from '../firebase';
 
 /** userChangeModal内で表示しているユーザ名を削除する処理 */
 export const deleteUserInfo = (info: string) => {
-  const collectionUserInfo = collection(db, "current_user_info");
+  const collectionUserInfo = collection(db, 'current_user_info');
   getDocs(collectionUserInfo)
     .then((querySnapshot) => {
       const { docs } = querySnapshot;
@@ -26,7 +26,7 @@ export const deleteUserInfo = (info: string) => {
 
 /** homeで表示しているTL情報を削除する処理 */
 export const deleteTimeline = () => {
-  const collectionTimeline = collection(db, "timeline_data");
+  const collectionTimeline = collection(db, 'timeline_data');
   getDocs(collectionTimeline)
     .then((querySnapshot) => {
       const { docs } = querySnapshot;
@@ -48,7 +48,7 @@ export const deleteTimeline = () => {
 
 /** 初回レンダリング時にhomeで表示している自分TL情報を削除する処理 */
 export const deleteMyTimeline = () => {
-  const collectionTimeline = collection(db, "my_timeline_data");
+  const collectionTimeline = collection(db, 'my_timeline_data');
   getDocs(collectionTimeline)
     .then((querySnapshot) => {
       const { docs } = querySnapshot;

--- a/src/common/errorBoundary.tsx
+++ b/src/common/errorBoundary.tsx
@@ -1,4 +1,4 @@
-import React, { Component, ErrorInfo, ReactNode } from "react";
+import React, { Component, ErrorInfo, ReactNode } from 'react';
 
 interface Props {
   children?: ReactNode;
@@ -19,7 +19,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   public static componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error("Uncaught error:", error, errorInfo);
+    console.error('Uncaught error:', error, errorInfo);
   }
 
   public render() {

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,14 +1,14 @@
-import { initializeApp } from "firebase/app";
-import { getFirestore } from "firebase/firestore";
+import { initializeApp } from 'firebase/app';
+import { getFirestore } from 'firebase/firestore';
 
 const firebaseConfig = {
-  apiKey: "AIzaSyC627-_40vtV1xsDPnmrHzu1q8XX9Qi9mk",
-  authDomain: "auto-twitter-c3781.firebaseapp.com",
-  projectId: "auto-twitter-c3781",
-  storageBucket: "auto-twitter-c3781.appspot.com",
-  messagingSenderId: "1012543334829",
-  appId: "1:1012543334829:web:960d3652bc18a07cb69924",
-  measurementId: "G-6P2KWEHTWC",
+  apiKey: 'AIzaSyC627-_40vtV1xsDPnmrHzu1q8XX9Qi9mk',
+  authDomain: 'auto-twitter-c3781.firebaseapp.com',
+  projectId: 'auto-twitter-c3781',
+  storageBucket: 'auto-twitter-c3781.appspot.com',
+  messagingSenderId: '1012543334829',
+  appId: '1:1012543334829:web:960d3652bc18a07cb69924',
+  measurementId: 'G-6P2KWEHTWC',
 };
 
 const app = initializeApp(firebaseConfig);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,6 @@
-import ReactDOM from "react-dom/client";
-import "../src/style/index.css";
-import App from "./App";
+import ReactDOM from 'react-dom/client';
+import '../src/style/index.css';
+import App from './App';
 
-const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
-);
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(<App />);

--- a/src/page/baseComponent/mainArea.tsx
+++ b/src/page/baseComponent/mainArea.tsx
@@ -1,37 +1,33 @@
 import Axios from 'axios';
-import {
-  collection,
-  getDocs,
-  query,
-  orderBy,
-  Timestamp
-} from 'firebase/firestore';
-import { useLayoutEffect } from 'react';
+import { collection, getDocs, query, orderBy, Timestamp } from 'firebase/firestore';
+import { useEffect } from 'react';
 import { useRecoilValue, useRecoilState } from 'recoil';
 import { UserInfoType } from '../../../@types/index';
 import { deleteMyTimeline } from '../../common/deleteTimeline';
 import db from '../../firebase';
-import userChangeState from '../../state/atoms/userChangeAtom';
-import '../../style/baseComponentStyle/mainAreaStyle.css';
 import videoIcon from '../../image/video_start.png';
+import modalChangeState from '../../state/atoms/modalFlagAtom';
+import myTimelineState from '../../state/atoms/myTimelineAtom';
+import '../../style/baseComponentStyle/mainAreaStyle.css';
 
 /** MainAreaコンポーネント */
 export default function MainArea() {
+  const myTimelineAreaFlg = useRecoilValue<boolean>(modalChangeState.myTimelineAreaFlgState);
+
   const videoIconUrl: string = videoIcon;
+
   /** myTimeline表示判定RecoilState
    * @type {boolean}
    * @description
    * ・true: 表示
    * ・false: 非表示
    */
-  const myTimelineFlg = useRecoilValue(userChangeState.myTimelineFlgState);
+  const getMyTimelineFlg = useRecoilValue<boolean>(myTimelineState.myTimelineGetFlgState);
 
   /** userTimeline用RecoilState
    * @type {UserInfoType[]}
    */
-  const [timeline, setTimeline] = useRecoilState<UserInfoType[]>(
-    userChangeState.userTimelineState
-  );
+  const [timeline, setTimeline] = useRecoilState<UserInfoType[]>(myTimelineState.userTimelineState);
 
   /** 自分のTL情報取得処理
    * @returns {UserInfoType[]} dataList(DB,my_timeline_dataに格納している値)
@@ -52,7 +48,7 @@ export default function MainArea() {
             video: doc.data().video as string,
             userId: doc.data().user_id as string,
             userName: doc.data().user_name as string,
-            tweetTime: doc.data().tweet_time as Timestamp
+            tweetTime: doc.data().tweet_time as Timestamp,
           };
           return dataList.push(resList);
         });
@@ -63,126 +59,87 @@ export default function MainArea() {
         console.log(querySnapshot);
       }
     );
+    deleteMyTimeline();
   };
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     Axios.post('http://127.0.0.1:5000/my_timeline')
       .then((response) => {
         console.log(response);
         catUserTimeLine();
-        deleteMyTimeline();
       })
       .catch((error) => {
         console.log('catch', error);
-        if (
-          Axios.isAxiosError(error) &&
-          error.response &&
-          error.response.status === 400
-        ) {
+        if (Axios.isAxiosError(error) && error.response && error.response.status === 400) {
           console.log(error.message);
         }
       });
     /** myTimelineFlgが更新される時に再レンダリングさせたいため、依存関係起因のeslintエラーを無視する */
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [myTimelineFlg]);
+  }, [getMyTimelineFlg]);
 
   return (
-    <div className="main-wrapper">
-      <div>
-        <p>プロフィール表示エリア</p>
-      </div>
-      <div className="main-wrapper--timeline">
-        {timeline.map((user, index) => (
-          <div className="timeline-contents" key={index.toString()}>
-            <p>{user.userName}</p>
-            <p>
-              {user.tweet.replace(
-                /https?:\/\/t.co\/[-_.!~*()a-zA-Z0-9;?:&=+,%#]+/gu,
-                ''
-              )}
-            </p>
-            <>
-              {user.video.length > 0 && (
-                <div className="video-contents">
-                  <video src={user.video} className="video-contents--item" />
-                  <a href={user.video} target="_blank" rel="noreferrer">
-                    <img
-                      src={videoIconUrl}
-                      alt="動画再生ボタン"
-                      className="video-contents--icon"
-                    />
-                  </a>
-                </div>
-              )}
-            </>
-            <div className="image-contents">
-              {user.media.length > 0 && (
-                <img
-                  src={user.media[0]}
-                  className="image-contents--single"
-                ></img>
-              )}
-              {user.media.length === 2 && (
-                <span className="image-contents--wrapper">
-                  <img
-                    src={user.media[0]}
-                    className="image-contents--mulch"
-                  ></img>
-                  <img
-                    src={user.media[1]}
-                    className="image-contents--mulch"
-                  ></img>
-                </span>
-              )}
-              {user.media.length === 3 && (
-                <span className="image-contents--wrapper">
-                  <img
-                    src={user.media[0]}
-                    className="image-contents--mulch"
-                  ></img>
-                  <img
-                    src={user.media[1]}
-                    className="image-contents--mulch"
-                  ></img>
-                  <img
-                    src={user.media[2]}
-                    className="image-contents--mulch"
-                  ></img>
-                </span>
-              )}
-              {user.media.length === 4 && (
-                <span className="image-contents--wrapper">
-                  <img
-                    src={user.media[0]}
-                    className="image-contents--mulch"
-                  ></img>
-                  <img
-                    src={user.media[1]}
-                    className="image-contents--mulch"
-                  ></img>
-                  <img
-                    src={user.media[2]}
-                    className="image-contents--mulch"
-                  ></img>
-                  <img
-                    src={user.media[3]}
-                    className="image-contents--mulch"
-                  ></img>
-                </span>
-              )}
-            </div>
-
-            <div className="timeline-contents--statusBar">
-              <p className="timeline-statusBar--retweet">⇄ {user.retweet}</p>
-              <p className="timeline-statusBar--favorite">♡ {user.favorite}</p>
-              <p>{user.tweetTime}</p>
-            </div>
+    <>
+      {myTimelineAreaFlg && (
+        <div className='main-wrapper'>
+          <div>
+            <p>プロフィール表示エリア</p>
           </div>
-        ))}
-      </div>
-      <div>
-        <p>TabContents表示エリア</p>
-      </div>
-    </div>
+          <div className='main-wrapper--timeline'>
+            {timeline.map((user, index) => (
+              <div className='timeline-contents' key={index.toString()}>
+                <p>{user.userName}</p>
+                <p>{user.tweet.replace(/https?:\/\/t.co\/[-_.!~*()a-zA-Z0-9;?:&=+,%#]+/gu, '')}</p>
+                <>
+                  {user.video.length > 0 && (
+                    <div className='video-contents'>
+                      <video src={user.video} className='video-contents--item' />
+                      <a href={user.video} target='_blank' rel='noreferrer'>
+                        <img src={videoIconUrl} alt='動画再生ボタン' className='video-contents--icon' />
+                      </a>
+                    </div>
+                  )}
+                </>
+                {user.media.length === 1 && (
+                  <div className='image-contents'>
+                    <img src={user.media[0]} className='image-contents--single'></img>
+                  </div>
+                )}
+                {user.media.length === 2 && (
+                  <div className='image-contents--wrapper'>
+                    <img src={user.media[0]} className='image-contents--mulch'></img>
+                    <img src={user.media[1]} className='image-contents--mulch'></img>
+                  </div>
+                )}
+                {user.media.length === 3 && (
+                  <div className='image-contents--wrapper'>
+                    <img src={user.media[0]} className='image-contents--mulch'></img>
+                    <img src={user.media[1]} className='image-contents--mulch'></img>
+                    <img src={user.media[2]} className='image-contents--mulch'></img>
+                  </div>
+                )}
+                {user.media.length === 4 && (
+                  <div className='image-contents--wrapper'>
+                    <img src={user.media[0]} className='image-contents--mulch'></img>
+                    <img src={user.media[1]} className='image-contents--mulch'></img>
+                    <img src={user.media[2]} className='image-contents--mulch'></img>
+                    <img src={user.media[3]} className='image-contents--mulch'></img>
+                  </div>
+                )}
+
+                <div className='timeline-contents--statusBar'>
+                  <p className='timeline-statusBar--retweet'>⇄ {user.retweet}</p>
+                  <p className='timeline-statusBar--favorite'>♡ {user.favorite}</p>
+                  <p>{user.tweetTime}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div>
+            <p>TabContents表示エリア</p>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/page/baseComponent/searchArea.tsx
+++ b/src/page/baseComponent/searchArea.tsx
@@ -1,10 +1,10 @@
-import React from "react";
-import "../../style/baseComponentStyle/searchAreaStyle.css";
+import React from 'react';
+import '../../style/baseComponentStyle/searchAreaStyle.css';
 
 /** SearchAreaコンポーネント */
 export default function SearchArea() {
   return (
-    <div className="search-wrapper">
+    <div className='search-wrapper'>
       <div>
         <p>検索バー表示エリア</p>
       </div>

--- a/src/page/baseComponent/sidebarArea.tsx
+++ b/src/page/baseComponent/sidebarArea.tsx
@@ -1,13 +1,60 @@
-import React from "react";
-import { Sidebar, Menu, MenuItem, SubMenu } from "react-pro-sidebar";
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { deleteTimeline } from '../../common/deleteTimeline';
+import modalChangeState from '../../state/atoms/modalFlagAtom';
+import myTimelineState from '../../state/atoms/myTimelineAtom';
+import '../../style/baseComponentStyle/sidebarAreaStyle.css';
+import { Sidebar, Menu, MenuItem, SubMenu } from 'react-pro-sidebar';
 
 /** MainAreaコンポーネント */
 export default function SidebarArea() {
+  /** MyTimeline表示制御用RecoilState
+   * @type {boolean} 自分のTLの表示を制御するようstate
+   */
+  const setMyTimelineAreaFlg = useSetRecoilState<boolean>(modalChangeState.myTimelineAreaFlgState);
+  /** UserChangeModal表示制御用RecoilState
+   * @type {boolean} 任意のuser情報取得modalの表示を制御するようstate
+   */
+  const setUserChangeModalFlg = useSetRecoilState<boolean>(modalChangeState.userChangeAreaFlgState);
+  /** MyTimeline項目2重クリック防止制御用RecoilState
+   * @type {boolean} MyTimeline箇所をクリックする度にTL取得情報が走ってしまうため、防止するようstate
+   */
+  const [getMyTimelineFlg, setGetMyTimelineFlg] = useRecoilState<boolean>(myTimelineState.myTimelineGetFlgState);
+
   return (
-    <Sidebar>
-      <Menu>
-        <SubMenu label="Twitter Contents1">
-          <MenuItem> Twitter Action1 </MenuItem>
+    <Sidebar className='sidebar-wrapper'>
+      <Menu className='sidebar-contents'>
+        <SubMenu label='timeline切り替え'>
+          <MenuItem
+            onClick={() => {
+              /** UserChangeModalを非表示にする */
+              setUserChangeModalFlg(false);
+              /** MyTimeline表示する */
+              setMyTimelineAreaFlg(true);
+              /** 2重クリック防止のため、getMyTimelineFlgの状態を参照する */
+              if (getMyTimelineFlg) {
+                setGetMyTimelineFlg(false);
+              } else {
+                setGetMyTimelineFlg(true);
+              }
+            }}
+          >
+            myTimeline
+          </MenuItem>
+          <MenuItem
+            onClick={() => {
+              /** 一度取得していた自身のTL情報を空にする */
+              deleteTimeline();
+              /** MyTimeline非表示する */
+              setMyTimelineAreaFlg(false);
+              /** UserChangeModalを表示にする */
+              setUserChangeModalFlg(true);
+            }}
+          >
+            userTimeline
+          </MenuItem>
+        </SubMenu>
+
+        <SubMenu label='Twitter Contents1'>
           <MenuItem> Twitter Action2 </MenuItem>
         </SubMenu>
         <MenuItem> Twitter Contents2 </MenuItem>

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";
+import '@testing-library/jest-dom';

--- a/src/state/atoms/modalFlagAtom.ts
+++ b/src/state/atoms/modalFlagAtom.ts
@@ -1,0 +1,20 @@
+import { atom } from 'recoil';
+
+/** MyTimeline表示制御Atom */
+export const myTimelineAreaFlgState = atom<boolean>({
+  key: 'MY_TIMELINE_FLG_AREA',
+  default: true,
+});
+
+/** UserChangeModal表示制御Atom */
+export const userChangeAreaFlgState = atom<boolean>({
+  key: 'CHANGE_USER_AREA_FLG',
+  default: false,
+});
+
+export const modalChangeState = {
+  myTimelineAreaFlgState,
+  userChangeAreaFlgState,
+};
+
+export default modalChangeState;

--- a/src/state/atoms/myTimelineAtom.ts
+++ b/src/state/atoms/myTimelineAtom.ts
@@ -1,0 +1,21 @@
+import { atom } from 'recoil';
+import { UserInfoType } from '../../../@types/index';
+
+/** UserChangeModal表示制御Atom */
+export const myTimelineGetFlgState = atom<boolean>({
+  key: 'MY_TIMELINE_GET_FLG',
+  default: true,
+});
+
+/** 表示するuserのTimeline用Atom */
+export const userTimelineState = atom<UserInfoType[]>({
+  key: 'TIMELINE_FLG',
+  default: [],
+});
+
+export const myTimelineState = {
+  userTimelineState,
+  myTimelineGetFlgState,
+};
+
+export default myTimelineState;

--- a/src/state/atoms/userChangeAtom.ts
+++ b/src/state/atoms/userChangeAtom.ts
@@ -1,35 +1,21 @@
-import { atom } from "recoil";
-import { UserType, UserInfoType } from "../../../@types/index";
-
-/** UserChangeModal表示制御Atom */
-export const myTimelineFlgState = atom<boolean>({
-  key: "MY_TIMELINE_FLG",
-  default: true,
-});
+import { atom } from 'recoil';
+import { UserType } from '../../../@types/index';
 
 /** UserChangeModal表示制御Atom */
 export const userChangeFlgState = atom<boolean>({
-  key: "CHANGE_USER_FLG",
+  key: 'CHANGE_USER_FLG',
   default: false,
-});
-
-/** 表示するuserのTimeline用Atom */
-export const userTimelineState = atom<UserInfoType[]>({
-  key: "TIMELINE_FLG",
-  default: [],
 });
 
 /** Timelineを表示する対象User用Atom */
 export const userInfoState = atom<UserType[]>({
-  key: "USER_INFO_FLG",
+  key: 'USER_INFO_FLG',
   default: [],
 });
 
 export const userChangeState = {
   userChangeFlgState,
-  userTimelineState,
   userInfoState,
-  myTimelineFlgState,
 };
 
 export default userChangeState;

--- a/src/style/app.css
+++ b/src/style/app.css
@@ -1,3 +1,16 @@
 .base-wrapper {
   display: flex;
+  margin-top: 5%;
+}
+
+.sidebar-wrapper {
+  min-width: 20%;
+}
+
+.main-wrapper {
+  min-width: 50%;
+}
+
+.search-wrapper {
+  min-width: 30%;
 }

--- a/src/style/baseComponentStyle/mainAreaStyle.css
+++ b/src/style/baseComponentStyle/mainAreaStyle.css
@@ -1,7 +1,6 @@
 /** 最上位要素ラップクラス*/
 .main-wrapper {
-  margin: 10px;
-  max-width: 50%;
+  margin: 0 10px;
 }
 
 /** timeline要素ラップクラス*/
@@ -35,7 +34,7 @@
 
 /** timeline内image複数ver用クラス*/
 .image-contents--mulch {
-  max-width: 50%;
+  max-width: 80%;
   height: auto;
   margin-left: 10px;
 }

--- a/src/style/baseComponentStyle/modalAreaStyle/userChangeStyle.css
+++ b/src/style/baseComponentStyle/modalAreaStyle/userChangeStyle.css
@@ -1,0 +1,95 @@
+@media screen and (max-width: 500px) {
+  .input-Wrapper {
+    flex-direction: column;
+  }
+}
+/** 最上位要素ラップクラス*/
+.userTimeline-wrapper {
+  margin: 0 10px;
+  padding: 0 20px 10px;
+  background-color: lightgray;
+  border: solid 1px;
+}
+
+/** modal上部ボタン要素ラップクラス */
+.button-wrapper {
+  display: flex;
+  justify-content: space-between;
+}
+
+/** modalボタンベースクラス */
+.button-style {
+  padding: 2px 6px;
+  cursor: pointer;
+  -webkit-transition: all 0.3s;
+  transition: all 0.3s;
+  border-radius: 0.2rem;
+}
+
+/** modal閉じるボタンhoverクラス */
+.button-style--closeButton:hover {
+  color: lightgray;
+  background: red;
+}
+
+/** modal要素追加ボタンhoverクラス */
+.button-style--addButton:hover {
+  color: lightgray;
+  background: skyblue;
+}
+
+/** modalTimeLine切り替えボタンクラス */
+.button-style--tlChangeButton {
+  width: 130px;
+  text-align: center;
+}
+
+/** modalTimeLine切り替えボタンhoverクラス */
+.button-style--tlChangeButton:hover {
+  color: lightgray;
+  background: #ff7321;
+}
+
+/** modalContents追加Areaラップクラス */
+.input-Wrapper {
+  display: flex;
+  justify-content: space-around;
+}
+
+/** modalContentsAreaクラス */
+.input-contents {
+  display: flex;
+}
+
+/** modalContents要素クラス */
+.input-contents--item {
+  height: 24px;
+  margin: 14px 0 0 10px;
+  padding-right: 5%;
+}
+
+/** modalContents要素accountName用クラス */
+.input-label--accountName {
+  width: 70px;
+}
+
+/** modalContents要素accountId用クラス */
+.input-label--accountId {
+  width: 100px;
+}
+
+/** userアカウント情報要素ラップクラス*/
+.userInfo-wrapper {
+  position: relative;
+  padding: 0 10px;
+  margin: 10px 0;
+  border: 1px solid;
+  display: flex;
+}
+
+/** userアカウント情報削除ボタンクラス*/
+.userInfo-removeIcon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+}

--- a/src/style/baseComponentStyle/sidebarAreaStyle.css
+++ b/src/style/baseComponentStyle/sidebarAreaStyle.css
@@ -1,0 +1,9 @@
+/** 最上位要素ラップクラス*/
+.sidebar-wrapper {
+  margin-top: 2px;
+}
+
+.sidebar-contents {
+  position: fixed;
+  width: 18%;
+}

--- a/src/twitterCommon/favorite.py
+++ b/src/twitterCommon/favorite.py
@@ -5,9 +5,9 @@ import time
 api = createAuthInfo.execute()
  
 # 検索キーワードと件数
-account_id = "itu0528"
+account_id = "srrarr_87"
 count = 500
-fix_count = 50
+fix_count = 100
 
 try_count = 0
 fav_count = 0
@@ -16,8 +16,8 @@ error_count = 0
 print( account_id + 'さんのツイートを' + str(fix_count) + '件いいねをします。')
 
 params = {
-    "exclude_replies": True,
     "count": count,
+    "exclude_replies": True,
     "include_rts": False         # リツイートを含むかどうか
 }
 
@@ -34,7 +34,7 @@ for tweet in api.user_timeline(id = account_id, params = params):
         print("tweet:" + tweet_text)                 # ツイート内容 
         print('【成功】' + '＠' + user_id + 'さんの「いいね」に成功しました。')
         fav_count += 1
-        time.sleep(5)
+        time.sleep(3)
         if fav_count == fix_count:
             print(f'指定件数{fix_count}件の「いいね」を実行しました。')
             break
@@ -42,6 +42,6 @@ for tweet in api.user_timeline(id = account_id, params = params):
         # すでに「いいね」済みだとこれが出力。
         print('【失敗】' + '＠' + user_id + 'さんの「いいね」に失敗しました。' + str(e))
         error_count += 1
-        time.sleep(5)
+        time.sleep(3)
         continue
 print(f'実行件数{try_count}件: 「いいね」件数{fav_count}件 / 「失敗」件数{error_count}件')

--- a/src/twitterCommon/follow.py
+++ b/src/twitterCommon/follow.py
@@ -8,7 +8,7 @@ api = createAuthInfo.execute()
 twitter_id = 'PiPiPi__PiEN___'
 
 # 検索キーワードと件数
-query = "#相互 -filter:retweets" # -filter:retweetsリツイートを除外するオプション
+query = "#フォロバ -filter:retweets" # -filter:retweetsリツイートを除外するオプション
 count = 500
 fix_count = 50
 

--- a/src/twitterCommon/userTimeline.py
+++ b/src/twitterCommon/userTimeline.py
@@ -8,39 +8,60 @@ import datetime
 api = createAuthInfo.execute()
 db_ref = execute_user_timeline()
 
-
 # 実行回数
-count = 30
+count = 300
 
 params = {
-    "exclude_replies": True,
-    "count": count,
-    }
+  "count": count,        # 取得するツイート数
+  "exclude_replies": True,    # リプライ(返信)を含まないかどうか(Trueで含まない)
+  "include_rts": False         # リツイートを含むかどうか
+}
+
 def timeline(account_id):
-    print(account_id)
-    selectUser = api.get_user(screen_name = account_id)
-    print(str(selectUser.name) + 'さんのタイムラインを取得します。')
-    for tweet in api.user_timeline(id = account_id, params = params):
-        print('-------------------------------------')   # 見やすくするための区切り
-        print('user_name:' + tweet.user.name)            # ユーザ名
-        print("user_id:" + tweet.user.screen_name)       # ユーザID
-        print("tweet:" + tweet.text)                     # ツイート内容
-        print("retweet:" + str(tweet.retweet_count))     # リツイート数
-        print("favorite:" + str(tweet.favorite_count))   # いいね数
-        print("tweet_time", str(tweet.created_at + timedelta(hours=+9)))
-        time = tweet.created_at + timedelta(hours=+9)
-        print(f'year: {time.year}, month: {time.month}, day: {time.day}')
-        print(f'hour: {time.hour}, minute: {time.minute}, second: {time.second}')
-        print(f'micro second: {time.microsecond}')
-        print(f'{time.year}:{time.month}/{time.day} {time.hour}:{time.minute}:{time.second}')
-        fix_time = (f'{time.year}:{time.month}/{time.day} {time.hour}:{time.minute}:{time.second}')
-        db_ref.document().set({
-            'user_name': tweet.user.name,
-            'user_id': tweet.user.screen_name,
-            'tweet': tweet.text,
-            'retweet': str(tweet.retweet_count),
-            'favorite': str(tweet.favorite_count),
-            'tweet_time': str(fix_time),
-            "tweet_created_at": tweet.created_at + timedelta(hours=+9),
-        })
-    return "SUCCESS"
+  media_list = [];
+  video = [];
+  get_count = 0
+  fix_count = 30
+  print(account_id)
+  selectUser = api.get_user(screen_name = account_id)
+  print(str(selectUser.name) + 'さんのタイムラインを取得します。')
+  for tweet in api.user_timeline(id = account_id, params = params):
+    print('-------------------------------------')   # 見やすくするための区切り
+    print('user_name:' + tweet.user.name)            # ユーザ名
+    print("user_id:" + tweet.user.screen_name)       # ユーザID
+    print("tweet:" + tweet.text)                     # ツイート内容
+    if 'media' in tweet.entities:
+      for media in tweet.extended_entities['media']:
+        if media.get('type', None) == 'video':
+          video.append(media['video_info']['variants'][0]['url'])
+        else: 
+          url = media['media_url_https']
+          media_list.append(url)
+    print("media_list:", media_list)                 # ツイート添付画像
+    print("retweet:" + str(tweet.retweet_count))     # リツイート数
+    print("favorite:" + str(tweet.favorite_count))   # いいね数
+    print("tweet_time", str(tweet.created_at + timedelta(hours=+9)))
+    time = tweet.created_at + timedelta(hours=+9)
+    print(f'year: {time.year}, month: {time.month}, day: {time.day}')
+    print(f'hour: {time.hour}, minute: {time.minute}, second: {time.second}')
+    print(f'micro second: {time.microsecond}')
+    print(f'{time.year}:{time.month}/{time.day} {time.hour}:{time.minute}:{time.second}')
+    fix_time = (f'{time.year}:{time.month}/{time.day} {time.hour}:{time.minute}:{time.second}')
+    get_count += 1
+    if get_count == fix_count:
+      print(f'指定件数{fix_count}件の「ツイート」を取得しました。')
+      break
+    db_ref.document().set({
+      'user_name': tweet.user.name,
+      'user_id': tweet.user.screen_name,
+      'tweet': tweet.text,
+      'media': media_list,
+      'video': video,
+      'retweet': str(tweet.retweet_count),
+      'favorite': str(tweet.favorite_count),
+      'tweet_time': str(fix_time),
+      "tweet_created_at": tweet.created_at + timedelta(hours=+9),
+    })
+    media_list = [];
+    video = [];
+  return "SUCCESS"


### PR DESCRIPTION
# sidebarコンテンツにユーザ切り替え用モーダルページ表示動線追加
sidebar箇所に対象ユーザのTLを取得する用modalコンテンツ追加。
- contents押下でuser切り替えmodalを表示する。
- 「myTimeline」「userTimeline」項目それぞれ紐づくページに遷移するように実装。

## 変更点

- src/App.tsx
- src/style/app.css
  - 最上位ページとして配置する項目の配置を調整致しました。

- src/page/baseComponent/mainArea.tsx
- src/state/atoms/userChangeAtom.ts
  - `getMyTimelineFlg `Atom更新時に自身のTL情報取得処理が走るように実装致しました。
  - mainAreaのスタイルを微調整致しました。

- src/page/baseComponent/sidebarArea.tsx
- src/style/baseComponentStyle/sidebarAreaStyle.css
  - sidebarにユーザ情報取得モーダル表示コンテンツを追加致しました。
  - それぞれの項目押下時に紐づくページが表示されるように実装致しました。
  - スタイルの調整を行いました。

- src/page/modalArea/userChangeModal.tsx
- src/style/baseComponentStyle/modalAreaStyle/userChangeStyle.css
  - ユーザ切り替え用modalを実装致しました。
  - スタイルの調整を行いました。

- src/state/atoms/modalFlagAtom.ts
- src/state/atoms/myTimelineAtom.ts
- src/state/atoms/userChangeAtom.ts
  - Atomを全て同じページで管理していたので、それぞれのページに対応するAtomを追加致しました。

